### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ match
 
 [![Binstar Badge](https://binstar.org/dmnapolitano/match/badges/version.svg)](https://binstar.org/dmnapolitano/match)[![Binstar Badge](https://binstar.org/dmnapolitano/match/badges/downloads.svg)](https://binstar.org/dmnapolitano/match)
 
-[![Latest Version](https://pypip.in/version/match/badge.svg)](https://pypi.python.org/pypi/match/)[![Downloads](https://pypip.in/download/match/badge.svg)](https://pypi.python.org/pypi/match/)
+[![Latest Version](https://img.shields.io/pypi/v/match.svg)](https://pypi.python.org/pypi/match/)[![Downloads](https://img.shields.io/pypi/dm/match.svg)](https://pypi.python.org/pypi/match/)
 
 The purpose of the module `Match` is to get the offsets (as well as the string between those offsets, for debugging) of a cleaned-up, tokenized string from its original, untokenized source.  "Big deal," you might say, but this is actually a pretty difficult task if the original text is sufficiently messy, not to mention rife with Unicode characters.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20match))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `match`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.