### PR TITLE
Make recipe noarch: python

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -5,6 +5,10 @@ package:
 source:
   git_url: https://github.com/EducationalTestingService/match.git
 
+build:
+  number: 1
+  noarch: python
+
 requirements:
   build:
     - python


### PR DESCRIPTION
This is not meant to be merged, only to display the changes between this branch and the `v0.2.2` tag. If it can be reviewed and approved, I would propose moving the `v0.2.2` tag to the HEAD of this branch and then declining this PR.