### PR TITLE
Better specifying the encoding in the function readme()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 def readme():
-    with open('README.rst', 'r') as f:
+    with open('README.rst', 'r', encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
The original line `with open('README.rst', 'r') as f:` caused "UnicodeDecodeError" on Windows 10.
Specify the encoding, `with open('README.rst', 'r', encoding='utf-8') as f:`, solved the problem.