### PR TITLE
Include py311 as supported version

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ..
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - cd $SRC_DIR
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python >=3.8,<3.10.0a0
+    - python >=3.8
     - nltk
     - regex
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='match',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
       ],
       packages=['match'],
       install_requires=requirements()


### PR DESCRIPTION
This PR adds Python 3.11 to the list of supported Python versions.